### PR TITLE
Return params instead of cloning it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,11 +94,8 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
 
   protected authorizationParams(params: URLSearchParams): URLSearchParams {
     params.set("scope", this.scope);
-    if (this.audience) {
-      params.set("audience", this.audience);
-    }
-
-    return new URLSearchParams(params);
+    if (this.audience) params.set("audience", this.audience);
+    return params
   }
 
   protected async userProfile(accessToken: string): Promise<Auth0Profile> {


### PR DESCRIPTION
I tried the latest version and is not setting any search param, not even the scope!

But I copied to code to my app and did this change and it worked, looks like doing `new URLSearchParams(params)` is, for some reason, not copying the params correctly.