### PR TITLE
Handle omitted `openid` scope

### DIFF
--- a/config/jest.config.ts
+++ b/config/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config.InitialOptions = {
   verbose: Boolean(process.env.CI),
   rootDir: path.resolve("."),
   collectCoverageFrom: ["<rootDir>/src/**/*.ts"],
+  resetMocks: false,
   setupFilesAfterEnv: ["<rootDir>/config/jest/setup.ts"],
   testMatch: ["<rootDir>/test/**/*.test.ts"],
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-auth-auth0",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-auth-auth0",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "remix-auth-oauth2": "^1.3.0"


### PR DESCRIPTION
When the `openid` scope is omitted, `id_token` is not returned from the `POST /oauth/token` request, and the `GET /userinfo` request fails.

This PR allows for the possibility of omitting the `openid` scope by
- making the `id_token` field optional in `Auth0ExtraParams`;
- skipping the wasted `GET /userinfo` request if the `openid` scope is not present; and 
- making the `Auth0Profile` fields optional to reflect that they may be omitted depending on which of the `openid`, `profile`, and `email` scopes are set, and whether the user profile even has that information present.

Also, the `expires_in` field is not guaranteed to be set to 86400 (this is the default but [can be configured](https://auth0.com/docs/secure/tokens/access-tokens/update-access-token-lifetime)), so I've widened the type for that to be `number`.