### PR TITLE
Added connection param to Auth0 strategy redirect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export interface Auth0StrategyOptions {
   scope?: string;
   audience?: string;
   organization?: string;
+  connection?: string;
 }
 
 export interface Auth0ExtraParams extends Record<string, unknown> {
@@ -63,6 +64,7 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
   private scope: string;
   private audience?: string;
   private organization?: string;
+  private connection?: string;
   private fetchProfile: boolean;
 
   constructor(
@@ -87,6 +89,7 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
     this.scope = options.scope || "openid profile email";
     this.audience = options.audience;
     this.organization = options.organization;
+    this.connection = options.connection;
     this.fetchProfile = /(^| )openid($| )/.test(this.scope);
   }
 
@@ -94,6 +97,7 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
     params.set("scope", this.scope);
     if (this.audience) params.set("audience", this.audience);
     if (this.organization) params.set("organization", this.organization);
+    if (this.connection) params.set("connection", this.connection);
     return params;
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -174,6 +174,39 @@ describe(Auth0Strategy, () => {
     }
   });
 
+  test("should allow setting the connection type", async () => {
+    let strategy = new Auth0Strategy(
+      {
+        domain: "test.fake.auth0.com",
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+        scope: "custom",
+        audience: "SOME_AUDIENCE",
+        organization: "SOME_ORG",
+        connection: "email",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/auth0");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("connection")).toBe("email");
+    }
+  });
+
   test("should not fetch user profile when openid scope is not present", async () => {
     let strategy = new Auth0Strategy(
       {


### PR DESCRIPTION
Hi @danestves 

I've hit a bit of friction with the passwordless flow as we need to add a connection param for either email or sms tot he authorize request.

I've tested this locally and it's all working but would be great to update the `npm` package for myself and others to use.

Thanks for the library anyway!

Cheers,

James