### PR TITLE
Expose `profile.org_id` as `profile.organizationId`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-auth-auth0",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-auth-auth0",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "remix-auth-oauth2": "^1.5.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,12 @@ interface Auth0UserInfo {
     country?: string;
   };
   updated_at?: string;
+  org_id?: string;
 }
 
 export interface Auth0Profile extends OAuth2Profile {
   _json?: Auth0UserInfo;
+  organizationId?: string;
 }
 
 export class Auth0Strategy<User> extends OAuth2Strategy<
@@ -147,6 +149,10 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
 
     if (data.picture) {
       profile.photos = [{ value: data.picture }];
+    }
+
+    if (data.org_id) {
+      profile.organizationId = data.org_id;
     }
 
     return profile;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -366,6 +366,7 @@ describe(Auth0Strategy, () => {
       locale: "en-US",
       phone_number: "+1 (111) 222-3434",
       phone_number_verified: false,
+      org_id: "some-auth0-organization-id",
       address: {
         country: "us",
       },
@@ -403,6 +404,7 @@ describe(Auth0Strategy, () => {
       },
       emails: [{ value: "janedoe@exampleco.com" }],
       photos: [{ value: "http://exampleco.com/janedoe/me.jpg" }],
+      organizationId: "some-auth0-organization-id",
     };
 
     expect(verify).toHaveBeenLastCalledWith({


### PR DESCRIPTION
Auth0's Organizations feature, if a client is using them, would expose an `org_id` parameter in the ID token as described [here](https://auth0.com/docs/manage-users/organizations/using-tokens#id-token)

This information is, of course, available under the `profile._json` parameter. However, this exposes it as an official, supported parameter so callers of this library don't have to use the internal `_json` property, which could change between minor versions.

(It also adds a commit that fixes `package-lock.json` so it matches the `package.json`'s `version` parameter.