### PR TITLE
Update peer dependency for remix-run/server-runtime to match dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "typescript": "5.2.2"
       },
       "peerDependencies": {
-        "@remix-run/server-runtime": "1.x",
+        "@remix-run/server-runtime": "2.x",
         "remix-auth": "3.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "@remix-run/server-runtime": "1.x",
+    "@remix-run/server-runtime": "2.x",
     "remix-auth": "3.x"
   }
 }


### PR DESCRIPTION
Update the peer dependency to match the dependency in the package. This will get rid of the error below when trying to do an npm install with version 2.x of the server-runtime.

<img width="663" alt="Screenshot 2023-10-18 at 10 09 31 AM" src="https://github.com/danestves/remix-auth-auth0/assets/1953556/43a5020a-1525-4237-af6a-d9c5444f5710">
