### PR TITLE
fix: additional search params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,13 +118,19 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
     return scope;
   }
 
-  protected authorizationParams() {
-    return new URLSearchParams({
-      scope: this.scope.join(Auth0StrategyScopeSeperator),
-      ...(this.audience && { audience: this.audience }),
-      ...(this.organization && { organization: this.organization }),
-      ...(this.connection && { connection: this.connection }),
-    });
+  protected authorizationParams(params: URLSearchParams) {
+    params.set("scope", this.scope.join(Auth0StrategyScopeSeperator));
+    if (this.audience) {
+      params.set("audience", this.audience);
+    }
+    if (this.organization) {
+      params.set("organization", this.organization);
+    }
+    if (this.connection) {
+      params.set("connection", this.connection);
+    }
+
+    return params;
   }
 
   protected async userProfile(accessToken: string): Promise<Auth0Profile> {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -418,4 +418,30 @@ describe(Auth0Strategy, () => {
       context,
     });
   });
+
+  test("should allow additional search params", async () => {
+    let strategy = new Auth0Strategy(
+      {
+        domain: "test.fake.auth0.com",
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+      },
+      verify,
+    );
+
+    let request = new Request("https://example.app/auth/auth0?test=1");
+    try {
+      await strategy.authenticate(request, sessionStorage, BASE_OPTIONS);
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("test")).toBe("1");
+    }
+  });
 });


### PR DESCRIPTION
closes #21 

as outlined in the docs of remix-auth-auth0 it should support the passing of additional search params, but this seems to have been broken in a recent change

one other note:

I could also do some checking to see if scope, audience, organization, connection are already set, and not override them but that could also be a followup PR