### PR TITLE
ci: using node lts to bump dependencies

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,17 +21,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
-          cache: "npm"
+          node-version: "lts/*"
+          registry-url: https://registry.npmjs.org/
+
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
+
       - name: Setup Git
         run: |
           git config user.name '${{ secrets.GIT_USER_NAME }}'
           git config user.email '${{ secrets.GIT_USER_EMAIL }}'
+
       - name: bump version
         run: npm version ${{ github.event.inputs.version }}
 


### PR DESCRIPTION
Instead of using `node@v16` we will always use `node@lts` to avoid any issues when bumping the repo