### PR TITLE
feat: Export Auth0UserInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export interface Auth0ExtraParams extends Record<string, unknown> {
   token_type: "Bearer";
 }
 
-interface Auth0UserInfo {
+export interface Auth0UserInfo {
   sub?: string;
   name?: string;
   given_name?: string;


### PR DESCRIPTION
This allows users to augment it with custom data.

I'm using it to augment type with metadata I'm returning.

```ts
declare module "remix-auth-auth0" {
	interface Auth0UserInfo {
		"https://my.prefix.domain/metadata"?: {
			company_name?: string;
		};
	}
}
```