### PR TITLE
Move debug package to dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,13 @@
       "dependencies": {
         "@mjackson/headers": "0.10.0",
         "arctic": "3.5.0",
+        "debug": "4.4.0",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@total-typescript/tsconfig": "1.0.4",
         "@types/bun": "1.2.5",
         "@types/debug": "4.1.12",
-        "debug": "4.4.0",
         "msw": "2.7.3",
         "typedoc": "0.28.1",
         "typedoc-plugin-mdn-links": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
 	},
 	"dependencies": {
 		"@mjackson/headers": "0.10.0",
-		"arctic": "3.5.0"
+		"arctic": "3.5.0",
+		"debug": "4.4.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@total-typescript/tsconfig": "1.0.4",
 		"@types/bun": "1.2.5",
 		"@types/debug": "4.1.12",
-		"debug": "4.4.0",
 		"msw": "2.7.3",
 		"typedoc": "0.28.1",
 		"typedoc-plugin-mdn-links": "5.0.1",


### PR DESCRIPTION
Required package in the code is now dev dependency and thus does not get installed when adding this dependency. Moved it to debug so i don't need to install debug myself.