### PR TITLE
fix: forward organization and invitation parameters for Auth0 organization invitations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,22 @@ export class Auth0Strategy<User> extends Strategy<
 		params: URLSearchParams,
 		request: Request,
 	): URLSearchParams {
-		return new URLSearchParams(params);
+		const newParams = new URLSearchParams(params);
+		const url = new URL(request.url);
+
+		// Forward organization parameter if present
+		const organization = url.searchParams.get("organization");
+		if (organization) {
+			newParams.set("organization", organization);
+		}
+
+		// Forward invitation parameter if present
+		const invitation = url.searchParams.get("invitation");
+		if (invitation) {
+			newParams.set("invitation", invitation);
+		}
+
+		return newParams;
 	}
 
 	/**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -54,6 +54,25 @@ describe(Auth0Strategy.name, () => {
 		server.close();
 	});
 
+	test("handles organization invitation parameters", async () => {
+		let strategy = new Auth0Strategy<User>(options, verify);
+
+		let orgParam = "org_123";
+		let invitationParam = "inv_456";
+
+		let request = new Request(
+			`https://remix.auth/login?organization=${orgParam}&invitation=${invitationParam}`,
+		);
+
+		let response = await catchResponse(strategy.authenticate(request));
+
+		// biome-ignore lint/style/noNonNullAssertion: This is a test
+		let redirect = new URL(response.headers.get("location")!);
+
+		expect(redirect.searchParams.get("organization")).toBe(orgParam);
+		expect(redirect.searchParams.get("invitation")).toBe(invitationParam);
+	});
+
 	test("should have the name `auth0`", () => {
 		let strategy = new Auth0Strategy<User>(options, verify);
 		expect(strategy.name).toBe("auth0");


### PR DESCRIPTION
This change enables support for Auth0 organization invitations by forwarding the organization and invitation parameters from the initial request to the Auth0 authorization URL. These parameters are required for the proper handling of invitation links as described in the Auth0 documentation: https://auth0.com/docs/manage-users/organizations/configure-organizations/invite-members

Closes https://github.com/danestves/remix-auth-auth0/issues/121