### PR TITLE
feat: support organization and audience parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,7 @@
 		".": "./build/index.js",
 		"./package.json": "./package.json"
 	},
-	"files": [
-		"build",
-		"package.json",
-		"README.md"
-	],
+	"files": ["build", "package.json", "README.md"],
 	"scripts": {
 		"build": "tsc",
 		"exports": "bun run ./scripts/exports.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export class Auth0Strategy<User> extends Strategy<
 	name = "auth0";
 
 	protected client: Auth0;
-	protected organization: string;
+	protected organization: string | undefined;
 
 	constructor(
 		protected options: Auth0Strategy.ConstructorOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export class Auth0Strategy<User> extends Strategy<
 	name = "auth0";
 
 	protected client: Auth0;
+	protected organization: string;
 
 	constructor(
 		protected options: Auth0Strategy.ConstructorOptions,
@@ -44,6 +45,8 @@ export class Auth0Strategy<User> extends Strategy<
 			options.clientSecret,
 			options.redirectURI.toString(),
 		);
+
+		this.organization = options.organization;
 	}
 
 	private get cookieName() {
@@ -165,12 +168,15 @@ export class Auth0Strategy<User> extends Strategy<
 
 		// Forward organization parameter if present
 		const organization = url.searchParams.get("organization");
+		const invitation = url.searchParams.get("invitation");
+
 		if (organization) {
 			newParams.set("organization", organization);
+		} else if (this.organization && !invitation) {
+			newParams.set("organization", this.organization);
 		}
 
 		// Forward invitation parameter if present
-		const invitation = url.searchParams.get("invitation");
 		if (invitation) {
 			newParams.set("invitation", invitation);
 		}
@@ -261,6 +267,12 @@ export namespace Auth0Strategy {
 		 * user.
 		 */
 		scopes?: Scope[];
+
+		/**
+		 * The organization to log the user in as a member of. If not provided, then
+		 * Auth0's organization functionality is not used.
+		 */
+		organization?: string;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export class Auth0Strategy<User> extends Strategy<
 
 	protected client: Auth0;
 	protected organization?: string;
-	protected audience?: string;
+	protected audience?: string | string[];
 
 	constructor(
 		protected options: Auth0Strategy.ConstructorOptions,
@@ -187,7 +187,13 @@ export class Auth0Strategy<User> extends Strategy<
 
 			// Forward audience from constructor if provided.
 			if (this.audience) {
-				newParams.set("audience", this.audience);
+				if (Array.isArray(this.audience)) {
+					for (const audience of this.audience) {
+						newParams.append("audience", audience);
+					}
+				} else {
+					newParams.append("audience", this.audience);
+				}
 			}
 		}
 
@@ -279,10 +285,10 @@ export namespace Auth0Strategy {
 		scopes?: Scope[];
 
 		/**
-		 * The unique identifier of the API to request access credentials for. If not provided, then
+		 * The unique identifier(s) of the API to request access credentials for. If not provided, then
 		 * Auth0 will return a token that can only access Auth0's authentication API.
 		 */
-		audience?: string;
+		audience?: string | string[];
 
 		/**
 		 * The organization to log the user in as a member of. If not provided, then

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,6 +38,15 @@ describe(Auth0Strategy.name, () => {
 		scopes: ["openid", "profile"],
 	} satisfies Auth0Strategy.ConstructorOptions);
 
+	let orgOptions = Object.freeze({
+		domain: "xxx.auth0.com",
+		clientId: "MY_CLIENT_ID",
+		clientSecret: "MY_CLIENT_SECRET",
+		redirectURI: "https://example.com/callback",
+		scopes: ["openid", "profile"],
+		organization: "testorg",
+	} satisfies Auth0Strategy.ConstructorOptions);
+
 	interface User {
 		id: string;
 	}
@@ -73,6 +82,26 @@ describe(Auth0Strategy.name, () => {
 		expect(redirect.searchParams.get("invitation")).toBe(invitationParam);
 	});
 
+	test("handles organization invitation parameters with organization", async () => {
+		let strategy = new Auth0Strategy<User>(orgOptions, verify);
+
+		let orgParam = "org_123";
+		let invitationParam = "inv_456";
+
+		let request = new Request(
+			`https://remix.auth/login?organization=${orgParam}&invitation=${invitationParam}`,
+		);
+
+		let response = await catchResponse(strategy.authenticate(request));
+
+		// biome-ignore lint/style/noNonNullAssertion: This is a test
+		let redirect = new URL(response.headers.get("location")!);
+
+		// ensure we get the organization we sent as part of the invitation back, rather than the org set on the options
+		expect(redirect.searchParams.get("organization")).toBe(orgParam);
+		expect(redirect.searchParams.get("invitation")).toBe(invitationParam);
+	});
+
 	test("should have the name `auth0`", () => {
 		let strategy = new Auth0Strategy<User>(options, verify);
 		expect(strategy.name).toBe("auth0");
@@ -95,8 +124,39 @@ describe(Auth0Strategy.name, () => {
 		expect(redirect.searchParams.get("response_type")).toBe("code");
 		expect(redirect.searchParams.get("client_id")).toBe(options.clientId);
 		expect(redirect.searchParams.get("redirect_uri")).toBe(options.redirectURI);
+		expect(redirect.searchParams.has("organization")).toBeFalsy();
 		expect(redirect.searchParams.has("state")).toBeTruthy();
 		expect(redirect.searchParams.get("scope")).toBe(options.scopes.join(" "));
+		expect(params.get("state")).toBe(redirect.searchParams.get("state"));
+		expect(redirect.searchParams.get("code_challenge_method")).toBe("S256");
+	});
+
+	test("redirects to authorization url if there's no state with organization", async () => {
+		let strategy = new Auth0Strategy<User>(orgOptions, verify);
+
+		let request = new Request("https://remix.auth/login");
+
+		let response = await catchResponse(strategy.authenticate(request));
+
+		// biome-ignore lint/style/noNonNullAssertion: This is a test
+		let redirect = new URL(response.headers.get("location")!);
+
+		let setCookie = new SetCookie(response.headers.get("set-cookie") ?? "");
+		let params = new URLSearchParams(setCookie.value);
+
+		expect(redirect.pathname).toBe("/authorize");
+		expect(redirect.searchParams.get("response_type")).toBe("code");
+		expect(redirect.searchParams.get("client_id")).toBe(orgOptions.clientId);
+		expect(redirect.searchParams.get("redirect_uri")).toBe(
+			orgOptions.redirectURI,
+		);
+		expect(redirect.searchParams.get("organization")).toBe(
+			orgOptions.organization,
+		);
+		expect(redirect.searchParams.has("state")).toBeTruthy();
+		expect(redirect.searchParams.get("scope")).toBe(
+			orgOptions.scopes.join(" "),
+		);
 		expect(params.get("state")).toBe(redirect.searchParams.get("state"));
 		expect(redirect.searchParams.get("code_challenge_method")).toBe("S256");
 	});


### PR DESCRIPTION
This PR enables Auth0's functionality around passing audience and organization parameters to the authorize endpoint, which were removed in the move from v1 to v2/Remix Auth v3 to v4.

The organization parameter allows for skipping the first page of the authorization workflow when the organization parameter is not known, if the tenant is using organization. Without this, users are required to entire their organization code on every login.

The audience parameter allows for returned access tokens to be used to access APIs known to the Auth0 tenant. Without the ability to pass an audience, the returned access token is only usable against Auth0's authentication API for calls like user profile information, which severely limits to usefulness of the token.

This change alters slightly the invitation organization functionality added in v2.1.0. If the invitation parameter is detected, then the organization from the invitation (if present) will be passed to the authorization endpoint; if we aren't hitting the logic due to an invitation, the organization passed to the constructor will be used.

Hopefully this is helpful! Both of these are requirements for us to migrate to v2, so we figured we should add them to the base package so others can similarly migrate.

Closes #118.